### PR TITLE
Fix deploy workflow lockfile flag

### DIFF
--- a/.github/workflows/deploy.prod.yaml
+++ b/.github/workflows/deploy.prod.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install --frozen-lockfile
-          cd infrastructure && yarn install --fronzen-lockfile
+          cd infrastructure && yarn install --frozen-lockfile
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3


### PR DESCRIPTION
## Summary
- fix the frozen lockfile flag in deploy.prod.yaml

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842dd1d1f908333875886e9b2d94399