### PR TITLE
Fix markdown glob patterns

### DIFF
--- a/app/lib/posts.server.ts
+++ b/app/lib/posts.server.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import matter from "gray-matter";
 
 // Import all markdown files using Vite's import.meta.glob
-const posts = import.meta.glob('/app/posts/*.(md|mdx)', {
+const posts = import.meta.glob('/app/posts/*.{md,mdx}', {
   eager: true,
   query: '?raw',
   import: 'default',

--- a/remix.config.js
+++ b/remix.config.js
@@ -3,8 +3,8 @@ module.exports = {
   tailwind: true,
   postcss: true,
   serverModuleFormat: "cjs",
-  serverDependenciesToBundle: [/^.$\.(md|mdx)$/],
-  watchPaths: [".app/posts/**/*.md", ".app/posts/**/*.mdx"],
+  serverDependenciesToBundle: [/^.*\.(md|mdx)$/],
+  watchPaths: ["./app/posts/**/*.md", "./app/posts/**/*.mdx"],
   future: {
     v2_errorBoundary: true,
     v2_headers: true,


### PR DESCRIPTION
## Summary
- fix import.meta.glob pattern to correctly match `.md` and `.mdx` files
- adjust Remix config patterns

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn typecheck` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc717538833390bba78c606f8fc0