### PR TITLE
Add Playwright E2E and CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,20 @@
+name: E2E Tests
+
+on:
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run E2E tests
+        run: yarn test:e2e

--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Blog', () => {
+  test('homepage lists posts', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('link', { name: 'Getting Started with Remix' })).toBeVisible();
+  });
+
+  test('filter posts by tag', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('nav').getByText('remix').click();
+    await expect(page.getByRole('link', { name: 'Getting Started with Remix' })).toBeVisible();
+  });
+
+  test('open post details', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Getting Started with Remix' }).click();
+    await expect(page.locator('h1')).toHaveText('Getting Started with Remix');
+  });
+
+  test('shows 404 page for unknown route', async ({ page }) => {
+    await page.goto('/non-existent');
+    await expect(page.getByText('Page Not Found')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "remix-serve ./build/server/index.js",
     "typecheck": "tsc",
-    "ui": "shadcn"
+    "ui": "shadcn",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
@@ -67,7 +68,8 @@
     "tailwindcss": "3",
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-tsconfig-paths": "^4.2.1",
+    "@playwright/test": "^1.42.1"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30 * 1000,
+  expect: {
+    timeout: 5000,
+  },
+  fullyParallel: true,
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+  webServer: {
+    command: 'yarn dev',
+    port: 5173,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- set up Playwright with a basic config
- add E2E tests covering the blog flow
- add npm script for running Playwright tests
- configure workflow to run tests on pull requests

## Testing
- `yarn test:e2e` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842e068818883338e8ba14369894ac3