### PR TITLE
Fix navigation z-index

### DIFF
--- a/app/components/blog/top-navigation.tsx
+++ b/app/components/blog/top-navigation.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 export function TopNavigation() {
   return (
-    <header className="border-b">
+    <header className="border-b relative z-50">
       <div className="container mx-auto px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-6">
           <h1 className="text-xl font-serif">


### PR DESCRIPTION
## Summary
- ensure the blog's top navigation renders above all content

## Testing
- `yarn lint` *(fails: package not present)*
- `yarn typecheck` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_e_684311db5ac08333890757d4e9b58f04