### PR TITLE
Fix nav z-index

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -35,7 +35,7 @@ export default function Index() {
       <TopNavigation />
 
       {/* Tags Navigation */}
-      <nav className="border-b sticky top-0 bg-background/80 backdrop-blur-sm">
+      <nav className="border-b sticky top-0 bg-background/80 backdrop-blur-sm relative z-50">
         <div className="container mx-auto px-4">
           <TagFilter
             tags={tags}


### PR DESCRIPTION
## Summary
- ensure sticky tags navigation uses same z-index as header

## Testing
- `yarn lint` *(fails: tunneling socket could not be established)*
- `yarn install` *(fails: tunneling socket could not be established)*

------
https://chatgpt.com/codex/tasks/task_e_684316ff1e748333a8ca0c0b41cccfa7